### PR TITLE
更新模块名称为 `github.com/gdt-dev-http`，以统一 HTTP 相关依赖。修改了 `eval_test.go` 和 …

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/gdt-dev/gdt"
 	api "github.com/gdt-dev/gdt/api"
-	gdthttp "github.com/gdt-dev/http"
-	"github.com/gdt-dev/http/test/server"
+	gdthttp "github.com/gdt-dev-http"
+	"github.com/gdt-dev-http/test/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gdt-dev/http
+module github.com/gdt-dev-http
 
 go 1.21
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gdt-dev/gdt"
 	"github.com/gdt-dev/gdt/api"
 	gdtjson "github.com/gdt-dev/gdt/assertion/json"
-	http "github.com/gdt-dev/http"
+	http "github.com/gdt-dev-http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
…`parse_test.go` 文件中的导入路径，确保与新模块名称一致。此更改提升了代码的一致性和可维护性。